### PR TITLE
Switch to travis-ci.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,8 +107,8 @@
         <a href="https://sourceforge.net/projects/cc65/files/contrib">User Contributions</a>
       </li>
       <li>
-        <a href="https://travis-ci.org/cc65/cc65/builds">
-          <img src="https://travis-ci.org/cc65/cc65.png" alt="Build Status"/>
+        <a href="https://app.travis-ci.com/cc65/cc65">
+          <img src="https://app.travis-ci.com/cc65/cc65.svg?branch=master" alt="Build Status"/>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
This changes the URL for builds and build status badge from
travis-ci.org to travis-ci.com

***

While reading the homepage, cc65.github.io, to learn about cc65, I noticed that the build status badge was "unknown".
The cc65 README switched to travis-ci.com in https://github.com/cc65/cc65/commit/2338e70709294a93d69d1f8bdc50d51509566b24.

I didn't use the *exact* links in the README (`?branch=master`, `.png` vs `.svg`) in order to keep things consistent with how they previously were in the homepage. Please let me know if they should be kept consistent with the README instead.