### PR TITLE
Move online documentation link to top links

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -15,6 +15,8 @@
           </li>
           <li id="here"><a href="getting-started.html">Getting Started</a>
           </li>
+          <li><a href="/doc">Documentation</a>
+          </li>
           <li><a href="mailing-lists.html">Mailing Lists</a>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
         </a>
       </li>
       <li>
-        <a href="https://github.com/cc65/doc/archive/refs/heads/master.zip" download="cc65-doc.zip">Download offline documentation</a>
+        <a href="doc/">Documentation</a> (<a href="https://github.com/cc65/doc/archive/refs/heads/master.zip" download="cc65-doc.zip">download</a>)
       </li>
       <li>
         <a href="https://github.com/cc65/wiki/wiki">Wiki</a>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
           </li>
           <li><a href="getting-started.html">Getting Started</a>
           </li>
+          <li><a href="/doc">Documentation</a>
+          </li>
           <li><a href="mailing-lists.html">Mailing Lists</a>
           </li>
         </ul>
@@ -111,7 +113,7 @@
         </a>
       </li>
       <li>
-        <a href="doc/">Documentation</a> (<a href="https://github.com/cc65/doc/archive/refs/heads/master.zip" download="cc65-doc.zip">download</a>)
+        <a href="https://github.com/cc65/doc/archive/refs/heads/master.zip" download="cc65-doc.zip">Download offline documentation</a>
       </li>
       <li>
         <a href="https://github.com/cc65/wiki/wiki">Wiki</a>

--- a/mailing-lists.html
+++ b/mailing-lists.html
@@ -15,6 +15,8 @@
           </li>
           <li><a href="getting-started.html">Getting Started</a>
           </li>
+          <li><a href="/doc">Documentation</a>
+          </li>
           <li id="here"><a href="mailing-lists.html">Mailing Lists</a>
           </li>
         </ul>


### PR DESCRIPTION
This makes the documentation easier to find from any page. The pages in the doc repository should probably also have this link for consistency.